### PR TITLE
Update server port to 8081

### DIFF
--- a/githubmirror.groovy
+++ b/githubmirror.groovy
@@ -207,7 +207,7 @@ def handleArgs(String[] args) {
   }
 
   if (options.s) {
-    startServer(options.p ? options.p as int : 8080, config)
+    startServer(options.p ? options.p as int : 8081, config)
   }
   else {
     mirrorGithubRepositorys(options.arguments() ?: [], config())


### PR DESCRIPTION
Listen to port 8081 because we have put an Apache in the front listening to
port 8080. This will give us access logs and hopefully be better at handling
stale connections.